### PR TITLE
chore: rollback parent version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20-SNAPSHOT</version>
+        <version>19</version>
     </parent>
 
     <groupId>io.gravitee.resource</groupId>
@@ -38,6 +38,7 @@
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
         <gravitee-gateway-api.version>1.24.0</gravitee-gateway-api.version>
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
+        <hazelcast.version>4.1.1</hazelcast.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
and declare hazelcast version in this pom.xml

Fixes gravitee-io/issues#599