### PR TITLE
feat(jupiter): implement getCache with jupiter ExecutionContext

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,14 +17,14 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>19.2.1</version>
+        <version>20.2</version>
     </parent>
 
     <groupId>io.gravitee.resource</groupId>
@@ -32,18 +32,34 @@
     <version>1.8.0</version>
 
     <name>Gravitee.io APIM - Resource - Cache</name>
-    <description>The resource is used to maintain a cache and link it to the API lifecycle. It means that the cache is initialized when the API is starting and released when API is stopped.</description>
+    <description>The resource is used to maintain a cache and link it to the API lifecycle. It means that the cache is initialized when the
+        API is starting and released when API is stopped.
+    </description>
 
     <properties>
+        <gravitee-bom.version>2.1</gravitee-bom.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
-        <gravitee-gateway-api.version>1.24.0</gravitee-gateway-api.version>
-        <gravitee-resource-cache-provider-api.version>1.1.0</gravitee-resource-cache-provider-api.version>
+        <gravitee-gateway-api.version>1.33.0-prototype-reactive-security-chain-SNAPSHOT</gravitee-gateway-api.version>
+        <gravitee-resource-cache-provider-api.version>1.2.0-prototype-reactive-security-chain-SNAPSHOT</gravitee-resource-cache-provider-api.version>
 
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <gravitee-node.version>1.20.0</gravitee-node.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/resources</publish-folder-path>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Import bom to properly inherit all dependencies -->
+            <dependency>
+                <groupId>io.gravitee</groupId>
+                <artifactId>gravitee-bom</artifactId>
+                <version>${gravitee-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- Gravitee.io API-->
@@ -79,7 +95,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>${spring.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -87,7 +102,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/io/gravitee/resource/cache/InMemoryCacheResource.java
+++ b/src/main/java/io/gravitee/resource/cache/InMemoryCacheResource.java
@@ -16,7 +16,7 @@
 package io.gravitee.resource.cache;
 
 import io.gravitee.common.utils.UUID;
-import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.reactive.api.context.ExecutionContext;
 import io.gravitee.node.api.cache.CacheConfiguration;
 import io.gravitee.node.api.cache.CacheManager;
 import io.gravitee.resource.cache.api.Cache;
@@ -63,7 +63,12 @@ public class InMemoryCacheResource extends CacheResource<CacheResourceConfigurat
     }
 
     @Override
-    public io.gravitee.resource.cache.api.Cache getCache(ExecutionContext executionContext) {
+    public io.gravitee.resource.cache.api.Cache getCache(ExecutionContext ctx) {
+        return this.cache;
+    }
+
+    @Override
+    public io.gravitee.resource.cache.api.Cache getCache(io.gravitee.gateway.api.ExecutionContext ctx) {
         return this.cache;
     }
 


### PR DESCRIPTION
Implement new `getCache(ctx)` method
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.8.0-prototype-reactive-security-chain-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache/1.8.0-prototype-reactive-security-chain-SNAPSHOT/gravitee-resource-cache-1.8.0-prototype-reactive-security-chain-SNAPSHOT.zip)
  <!-- Version placeholder end -->
