### PR TITLE
fix: don't put element in cache with ttl greater than cache ttl

### DIFF
--- a/src/main/java/io/gravitee/resource/cache/InMemoryCacheResource.java
+++ b/src/main/java/io/gravitee/resource/cache/InMemoryCacheResource.java
@@ -80,7 +80,12 @@ public class InMemoryCacheResource extends CacheResource<CacheResourceConfigurat
         configuration.setTimeToIdleSeconds((int) configuration().getTimeToIdleSeconds());
         configuration.setTimeToLiveSeconds((int) configuration().getTimeToLiveSeconds());
 
-        this.cache = new InMemoryCacheDelegate(cacheId, cacheManager.getOrCreateCache(cacheId, configuration));
+        this.cache =
+            new InMemoryCacheDelegate(
+                cacheId,
+                configuration().getTimeToLiveSeconds(),
+                cacheManager.getOrCreateCache(cacheId, configuration)
+            );
     }
 
     @Override

--- a/src/test/java/io/gravitee/resource/cache/inmemory/InMemoryCacheDelegateTest.java
+++ b/src/test/java/io/gravitee/resource/cache/inmemory/InMemoryCacheDelegateTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.cache.inmemory;
+
+import static org.mockito.Mockito.*;
+
+import io.gravitee.node.api.cache.Cache;
+import io.gravitee.resource.cache.api.Element;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InMemoryCacheDelegateTest {
+
+    private static final int CACHE_TTL = 60;
+    private static String ELEMENT_KEY = "test-key";
+    private static String ELEMENT_VALUE = "test-value";
+
+    private InMemoryCacheDelegate inMemoryCacheDelegate;
+
+    private Cache mockCache;
+    private Element mockElement;
+
+    @Before
+    public void setup() {
+        mockCache = mock(Cache.class);
+        inMemoryCacheDelegate = new InMemoryCacheDelegate("test-cache", CACHE_TTL, mockCache);
+        mockElement = mock(Element.class);
+        when(mockElement.key()).thenReturn(ELEMENT_KEY);
+        when(mockElement.value()).thenReturn(ELEMENT_VALUE);
+    }
+
+    @Test
+    public void shouldPutWithElementTtlLowerThanCacheTtl() {
+        when(mockElement.timeToLive()).thenReturn(CACHE_TTL - 10);
+
+        inMemoryCacheDelegate.put(mockElement);
+
+        verify(mockCache).put(ELEMENT_KEY, ELEMENT_VALUE, CACHE_TTL - 10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void shouldPutWithElementTtlHigherThanCacheTtl() {
+        when(mockElement.timeToLive()).thenReturn(CACHE_TTL + 10);
+
+        inMemoryCacheDelegate.put(mockElement);
+
+        verify(mockCache).put(ELEMENT_KEY, ELEMENT_VALUE, CACHE_TTL, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void shouldPutWithElementTtlZero() {
+        when(mockElement.timeToLive()).thenReturn(0);
+
+        inMemoryCacheDelegate.put(mockElement);
+
+        verify(mockCache).put(ELEMENT_KEY, ELEMENT_VALUE, CACHE_TTL, TimeUnit.SECONDS);
+    }
+}


### PR DESCRIPTION
**Description**

fix: don't put element in cache with ttl greater than cache ttl

With this change, ttl is handled the same way as in resource-cache-redis : https://github.com/gravitee-io/gravitee-resource-cache-redis/blob/master/src/main/java/io/gravitee/resource/cache/redis/RedisDelegate.java#L99

This avoids this kind of exceptions :
```
com.google.common.base.VerifyException: single ttl can't be bigger than ttl defined in the configuration
	at com.google.common.base.Verify.verify(Verify.java:126)
	at io.gravitee.node.cache.standalone.StandaloneCache.put(StandaloneCache.java:129)
	at io.gravitee.resource.cache.inmemory.InMemoryCacheDelegate.put(InMemoryCacheDelegate.java:68)
```

**Issue**

https://github.com/gravitee-io/issues/issues/7907
https://github.com/gravitee-io/issues/issues/8295
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.8.1-fix-elementTtlGreaterThanCacheTtl-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache/1.8.1-fix-elementTtlGreaterThanCacheTtl-SNAPSHOT/gravitee-resource-cache-1.8.1-fix-elementTtlGreaterThanCacheTtl-SNAPSHOT.zip)
  <!-- Version placeholder end -->
