### PR TITLE
chore: rename 'jupiter' package in 'reactive'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ workflows:
     setup_release:
         when:
             matches:
-                pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
             - gravitee/setup_plugin-release-config:
@@ -32,4 +32,4 @@ workflows:
                               - /.*/
                       tags:
                           only:
-                              - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
     <properties>
         <gravitee-bom.version>2.1</gravitee-bom.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
-        <gravitee-gateway-api.version>1.44.0</gravitee-gateway-api.version>
-        <gravitee-resource-cache-provider-api.version>1.3.0</gravitee-resource-cache-provider-api.version>
+        <gravitee-gateway-api.version>2.1.0-alpha.18</gravitee-gateway-api.version>
+        <gravitee-resource-cache-provider-api.version>1.4.0-alpha.1</gravitee-resource-cache-provider-api.version>
 
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <gravitee-node.version>1.20.0</gravitee-node.version>

--- a/src/main/java/io/gravitee/resource/cache/InMemoryCacheResource.java
+++ b/src/main/java/io/gravitee/resource/cache/InMemoryCacheResource.java
@@ -16,8 +16,8 @@
 package io.gravitee.resource.cache;
 
 import io.gravitee.common.utils.UUID;
-import io.gravitee.gateway.jupiter.api.context.ExecutionContext;
-import io.gravitee.gateway.jupiter.api.context.GenericExecutionContext;
+import io.gravitee.gateway.reactive.api.context.ExecutionContext;
+import io.gravitee.gateway.reactive.api.context.GenericExecutionContext;
 import io.gravitee.node.api.cache.CacheConfiguration;
 import io.gravitee.node.api.cache.CacheManager;
 import io.gravitee.resource.cache.api.Cache;


### PR DESCRIPTION
related to APIM-718

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.10.0-apim-718-rename-v4-terms-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache/1.10.0-apim-718-rename-v4-terms-SNAPSHOT/gravitee-resource-cache-1.10.0-apim-718-rename-v4-terms-SNAPSHOT.zip)
  <!-- Version placeholder end -->
