### PR TITLE
feat: bump gravitee node version to use latest cache plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.resource</groupId>
     <artifactId>gravitee-resource-cache</artifactId>
-    <version>1.10.0-alpha.1</version>
+    <version>1.10.0-archi-231-cache-manager-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Resource - Cache</name>
     <description>The resource is used to maintain a cache and link it to the API lifecycle. It means that the cache is initialized when the
@@ -43,7 +43,7 @@
         <gravitee-resource-cache-provider-api.version>1.4.0-alpha.1</gravitee-resource-cache-provider-api.version>
 
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
-        <gravitee-node.version>1.20.0</gravitee-node.version>
+        <gravitee-node.version>3.1.0-alpha.5</gravitee-node.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/resources</publish-folder-path>
     </properties>
@@ -86,7 +86,7 @@
 
         <dependency>
             <groupId>io.gravitee.node</groupId>
-            <artifactId>gravitee-node-cache</artifactId>
+            <artifactId>gravitee-node-api</artifactId>
             <version>${gravitee-node.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/src/main/java/io/gravitee/resource/cache/NodeCacheDelegate.java
+++ b/src/main/java/io/gravitee/resource/cache/NodeCacheDelegate.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.resource.cache.inmemory;
+package io.gravitee.resource.cache;
 
 import io.gravitee.resource.cache.api.Cache;
 import io.gravitee.resource.cache.api.Element;
@@ -23,13 +23,13 @@ import java.util.concurrent.TimeUnit;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class InMemoryCacheDelegate implements Cache {
+public class NodeCacheDelegate implements Cache {
 
     private final String name;
     private final long timeToLiveSeconds;
     private final io.gravitee.node.api.cache.Cache wrapped;
 
-    public InMemoryCacheDelegate(final String name, long timeToLiveSeconds, final io.gravitee.node.api.cache.Cache wrapped) {
+    public NodeCacheDelegate(final String name, long timeToLiveSeconds, final io.gravitee.node.api.cache.Cache wrapped) {
         this.name = name;
         this.timeToLiveSeconds = timeToLiveSeconds;
         this.wrapped = wrapped;

--- a/src/main/java/io/gravitee/resource/cache/configuration/CacheResourceConfiguration.java
+++ b/src/main/java/io/gravitee/resource/cache/configuration/CacheResourceConfiguration.java
@@ -16,11 +16,15 @@
 package io.gravitee.resource.cache.configuration;
 
 import io.gravitee.resource.api.ResourceConfiguration;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Getter
+@Setter
 public class CacheResourceConfiguration implements ResourceConfiguration {
 
     public static final char KEY_SEPARATOR = '_';
@@ -31,36 +35,4 @@ public class CacheResourceConfiguration implements ResourceConfiguration {
     private long timeToLiveSeconds = 0;
 
     private long maxEntriesLocalHeap = 1000;
-
-    public long getMaxEntriesLocalHeap() {
-        return maxEntriesLocalHeap;
-    }
-
-    public void setMaxEntriesLocalHeap(long maxEntriesLocalHeap) {
-        this.maxEntriesLocalHeap = maxEntriesLocalHeap;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public long getTimeToIdleSeconds() {
-        return timeToIdleSeconds;
-    }
-
-    public void setTimeToIdleSeconds(long timeToIdleSeconds) {
-        this.timeToIdleSeconds = timeToIdleSeconds;
-    }
-
-    public long getTimeToLiveSeconds() {
-        return timeToLiveSeconds;
-    }
-
-    public void setTimeToLiveSeconds(long timeToLiveSeconds) {
-        this.timeToLiveSeconds = timeToLiveSeconds;
-    }
 }

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -2,6 +2,6 @@ id=cache
 name=Cache
 version=${project.version}
 description=${project.description}
-class=io.gravitee.resource.cache.InMemoryCacheResource
+class=io.gravitee.resource.cache.NodeCacheResource
 type=resource
 icon=resource-cache.svg

--- a/src/test/java/io/gravitee/resource/cache/inmemory/NodeCacheDelegateTest.java
+++ b/src/test/java/io/gravitee/resource/cache/inmemory/NodeCacheDelegateTest.java
@@ -15,9 +15,12 @@
  */
 package io.gravitee.resource.cache.inmemory;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.gravitee.node.api.cache.Cache;
+import io.gravitee.resource.cache.NodeCacheDelegate;
 import io.gravitee.resource.cache.api.Element;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
@@ -26,13 +29,13 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class InMemoryCacheDelegateTest {
+public class NodeCacheDelegateTest {
 
     private static final int CACHE_TTL = 60;
-    private static String ELEMENT_KEY = "test-key";
-    private static String ELEMENT_VALUE = "test-value";
+    private static final String ELEMENT_KEY = "test-key";
+    private static final String ELEMENT_VALUE = "test-value";
 
-    private InMemoryCacheDelegate inMemoryCacheDelegate;
+    private NodeCacheDelegate inMemoryCacheDelegate;
 
     private Cache mockCache;
     private Element mockElement;
@@ -40,7 +43,7 @@ public class InMemoryCacheDelegateTest {
     @Before
     public void setup() {
         mockCache = mock(Cache.class);
-        inMemoryCacheDelegate = new InMemoryCacheDelegate("test-cache", CACHE_TTL, mockCache);
+        inMemoryCacheDelegate = new NodeCacheDelegate("test-cache", CACHE_TTL, mockCache);
         mockElement = mock(Element.class);
         when(mockElement.key()).thenReturn(ELEMENT_KEY);
         when(mockElement.value()).thenReturn(ELEMENT_VALUE);


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-231

**Description**

Use newest cache manager plugin


<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.10.0-archi-231-cache-manager-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache/1.10.0-archi-231-cache-manager-SNAPSHOT/gravitee-resource-cache-1.10.0-archi-231-cache-manager-SNAPSHOT.zip)
  <!-- Version placeholder end -->
