### PR TITLE
feat: rework schema-form to use new GioJsonSchema Ui component

### DIFF
--- a/src/main/java/io/gravitee/resource/cache/NodeCacheResource.java
+++ b/src/main/java/io/gravitee/resource/cache/NodeCacheResource.java
@@ -47,7 +47,7 @@ public class NodeCacheResource
         super.doStart();
 
         final CacheResourceConfiguration configuration = configuration();
-        this.cacheId = MAP_PREFIX + configuration.getName() + CacheResourceConfiguration.KEY_SEPARATOR + UUID.random().toString();
+        this.cacheId = MAP_PREFIX + "gravitee" + CacheResourceConfiguration.KEY_SEPARATOR + UUID.random().toString();
         this.cacheManager = this.applicationContext.getBean(CacheManager.class);
 
         buildCache();

--- a/src/main/java/io/gravitee/resource/cache/configuration/CacheResourceConfiguration.java
+++ b/src/main/java/io/gravitee/resource/cache/configuration/CacheResourceConfiguration.java
@@ -28,7 +28,6 @@ import lombok.Setter;
 public class CacheResourceConfiguration implements ResourceConfiguration {
 
     public static final char KEY_SEPARATOR = '_';
-    private String name = "my-cache";
 
     private long timeToIdleSeconds = 0;
 

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -5,3 +5,4 @@ description=${project.description}
 class=io.gravitee.resource.cache.NodeCacheResource
 type=resource
 icon=resource-cache.svg
+category=Cache

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,6 +1,6 @@
 {
     "type": "object",
-    "id": "urn:jsonschema:io:gravitee:resource:cache:configuration:CacheResourceConfiguration",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {
         "name": {
             "title": "Cache name",
@@ -30,5 +30,5 @@
             "minimum": 0
         }
     },
-    "required": ["name", "timeToIdleSeconds", "timeToLiveSeconds", "maxEntriesLocalHeap", "timeToLiveSeconds"]
+    "required": ["name", "timeToIdleSeconds", "maxEntriesLocalHeap", "timeToLiveSeconds"]
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -2,12 +2,6 @@
     "type": "object",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {
-        "name": {
-            "title": "Cache name",
-            "description": "The name of the cache.",
-            "type": "string",
-            "default": "my-cache"
-        },
         "timeToIdleSeconds": {
             "title": "Time to idle (in seconds)",
             "type": "integer",
@@ -30,5 +24,5 @@
             "minimum": 0
         }
     },
-    "required": ["name", "timeToIdleSeconds", "maxEntriesLocalHeap", "timeToLiveSeconds"]
+    "required": ["timeToIdleSeconds", "maxEntriesLocalHeap", "timeToLiveSeconds"]
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2212

**Description**

![image](https://github.com/gravitee-io/gravitee-resource-cache/assets/4974420/3c81fbfc-4c6c-4662-a904-1a05081e7f82)
![image](https://github.com/gravitee-io/gravitee-resource-cache/assets/4974420/f518d608-360a-431e-a7c6-cd44afd4b380)

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-APIM-2364-json-schema-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache/2.1.0-APIM-2364-json-schema-SNAPSHOT/gravitee-resource-cache-2.1.0-APIM-2364-json-schema-SNAPSHOT.zip)
  <!-- Version placeholder end -->
