### PR TITLE
Use latest cache provider api

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,9 @@
-**Issue**
+## Issue
 
-https://github.com/gravitee-io/issues/issues/XXXXX
+https://gravitee.atlassian.net/browse/XXXXX
 
-**Description**
+## Description
 
 A small description of what you did in that PR.
 
-**Additional context**
-
-<!-- Add any other context about the PR here -->
-<!-- It can be links to other PRs or docs or drawing -->
-<!-- Or reproduction steps in case of bug fix -->
+## Additional context

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,25 +1,3 @@
 {
-    "extends": ["config:base", ":label(dependencies)"],
-    "rebaseWhen": "conflicted",
-    "packageRules": [
-        {
-            "matchDatasources": ["orb"],
-            "matchUpdateTypes": ["patch", "minor"],
-            "automerge": true,
-            "automergeType": "branch",
-            "semanticCommitType": "ci"
-        },
-        {
-            "matchDepTypes": ["provided", "test", "build", "import", "parent"],
-            "matchUpdateTypes": ["patch", "minor"],
-            "automerge": true,
-            "automergeType": "branch",
-            "semanticCommitType": "chore"
-        },
-        {
-            "matchDepTypes": ["provided", "test", "build", "import", "parent"],
-            "matchUpdateTypes": ["major"],
-            "semanticCommitType": "chore"
-        }
-    ]
+    "extends": ["github>gravitee-io/renovate-config:policy"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ hs_err_pid*
 # Idea files
 /.idea/
 /*.iml
+
+.DS_Store
+
 # -- Cicd : Git ignore the [.circleci/**/*] which contains
 # files which do not need to be commited (password to artifactory)
 .circleci/**/*

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.resource</groupId>
     <artifactId>gravitee-resource-cache</artifactId>
-    <version>2.1.0</version>
+    <version>3.0.0-APIM-7152-use-latest-cache-provider-api-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Resource - Cache</name>
     <description>The resource is used to maintain a cache and link it to the API lifecycle. It means that the cache is initialized when the
@@ -39,9 +39,9 @@
     <properties>
         <gravitee-bom.version>6.0.60</gravitee-bom.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
-        <gravitee-gateway-api.version>3.8.1</gravitee-gateway-api.version>
-        <gravitee-resource-cache-provider-api.version>1.4.0</gravitee-resource-cache-provider-api.version>
         <gravitee-node.version>4.8.6</gravitee-node.version>
+        <gravitee-gateway-api.version>3.9.0-alpha.11</gravitee-gateway-api.version>
+        <gravitee-resource-cache-provider-api.version>2.0.0</gravitee-resource-cache-provider-api.version>
 
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,11 @@
     </description>
 
     <properties>
-        <gravitee-bom.version>6.0.60</gravitee-bom.version>
+        <gravitee-bom.version>8.1.16</gravitee-bom.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
-        <gravitee-node.version>4.8.6</gravitee-node.version>
         <gravitee-gateway-api.version>3.9.0-alpha.11</gravitee-gateway-api.version>
         <gravitee-resource-cache-provider-api.version>2.0.0</gravitee-resource-cache-provider-api.version>
+        <gravitee-node.version>7.0.0-alpha.1</gravitee-node.version>
 
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>

--- a/src/main/java/io/gravitee/resource/cache/NodeCacheResource.java
+++ b/src/main/java/io/gravitee/resource/cache/NodeCacheResource.java
@@ -17,6 +17,7 @@ package io.gravitee.resource.cache;
 
 import io.gravitee.common.utils.UUID;
 import io.gravitee.gateway.reactive.api.context.GenericExecutionContext;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.node.api.cache.CacheConfiguration;
 import io.gravitee.node.api.cache.CacheManager;
 import io.gravitee.resource.cache.api.Cache;
@@ -79,6 +80,11 @@ public class NodeCacheResource
 
     @Override
     public io.gravitee.resource.cache.api.Cache getCache(final GenericExecutionContext ctx) {
+        return this.cache;
+    }
+
+    @Override
+    public Cache getCache(BaseExecutionContext ctx) {
         return this.cache;
     }
 


### PR DESCRIPTION
## Issue

gravitee.atlassian.net/browse/APIM-7152

## Description

Implements getCache for BaseExecutionContext

**BREAKING CHANGE**: requires gravitee-gateway-api 3.9.0+ & resource-cache-provider-api 2.0.0+
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-APIM-7152-use-latest-cache-provider-api-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache/3.0.0-APIM-7152-use-latest-cache-provider-api-SNAPSHOT/gravitee-resource-cache-3.0.0-APIM-7152-use-latest-cache-provider-api-SNAPSHOT.zip)
  <!-- Version placeholder end -->
