### PR TITLE
feat(cache): validate async cache API for in-memory resource

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
         <gravitee-gateway-api.version>3.13.0</gravitee-gateway-api.version>
         <gravitee-node.version>7.26.1</gravitee-node.version>
-        <gravitee-resource-cache-provider-api.version>2.0.0</gravitee-resource-cache-provider-api.version>
+        <gravitee-resource-cache-provider-api.version>2.1.0</gravitee-resource-cache-provider-api.version>
 
         <maven-assembly-plugin.version>3.8.0</maven-assembly-plugin.version>
         <properties-maven-plugin.version>1.3.0</properties-maven-plugin.version>
@@ -117,6 +117,12 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/io/gravitee/resource/cache/inmemory/NodeCacheDelegateAsyncTest.java
+++ b/src/test/java/io/gravitee/resource/cache/inmemory/NodeCacheDelegateAsyncTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.cache.inmemory;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.node.api.cache.Cache;
+import io.gravitee.resource.cache.NodeCacheDelegate;
+import io.gravitee.resource.cache.api.Element;
+import io.vertx.core.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NodeCacheDelegateAsyncTest {
+
+    private static final int CACHE_TTL = 60;
+    private static final String ELEMENT_KEY = "test-key";
+    private static final String ELEMENT_VALUE = "test-value";
+
+    private NodeCacheDelegate delegate;
+    private Cache mockCache;
+
+    @Before
+    public void setup() {
+        mockCache = mock(Cache.class);
+        delegate = new NodeCacheDelegate("test-cache", CACHE_TTL, mockCache);
+    }
+
+    @Test
+    public void shouldGetElementViaAsyncFuture() {
+        when(mockCache.get(ELEMENT_KEY)).thenReturn(ELEMENT_VALUE);
+
+        Future<Element> future = delegate.getAsync(ELEMENT_KEY);
+
+        assertTrue(future.succeeded());
+        assertNotNull(future.result());
+        assertEquals(ELEMENT_KEY, future.result().key());
+        assertEquals(ELEMENT_VALUE, future.result().value());
+    }
+
+    @Test
+    public void shouldReturnNullElementForMissingKey() {
+        when(mockCache.get("missing-key")).thenReturn(null);
+
+        Future<Element> future = delegate.getAsync("missing-key");
+
+        assertTrue(future.succeeded());
+        assertNull(future.result());
+    }
+
+    @Test
+    public void shouldPutElementViaAsyncFuture() {
+        var element = mock(Element.class);
+        when(element.key()).thenReturn(ELEMENT_KEY);
+        when(element.value()).thenReturn(ELEMENT_VALUE);
+        when(element.timeToLive()).thenReturn(30);
+
+        Future<Void> future = delegate.putAsync(element);
+
+        assertTrue(future.succeeded());
+        verify(mockCache).put(ELEMENT_KEY, ELEMENT_VALUE, 30, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void shouldEvictElementViaAsyncFuture() {
+        Future<Void> future = delegate.evictAsync(ELEMENT_KEY);
+
+        assertTrue(future.succeeded());
+        verify(mockCache).evict(ELEMENT_KEY);
+    }
+
+    @Test
+    public void shouldClearViaAsyncFuture() {
+        Future<Void> future = delegate.clearAsync();
+
+        assertTrue(future.succeeded());
+        verify(mockCache).clear();
+    }
+
+    @Test
+    public void shouldHandleGetErrorViaFailedFuture() {
+        when(mockCache.get(ELEMENT_KEY)).thenThrow(new RuntimeException("cache failure"));
+
+        Future<Element> future = delegate.getAsync(ELEMENT_KEY);
+
+        assertTrue(future.failed());
+        assertEquals("cache failure", future.cause().getMessage());
+    }
+
+    @Test
+    public void shouldHandlePutErrorViaFailedFuture() {
+        var element = mock(Element.class);
+        when(element.key()).thenReturn(ELEMENT_KEY);
+        when(element.value()).thenReturn(ELEMENT_VALUE);
+        when(element.timeToLive()).thenReturn(30);
+        doThrow(new RuntimeException("put failure")).when(mockCache).put(ELEMENT_KEY, ELEMENT_VALUE, 30, TimeUnit.SECONDS);
+
+        Future<Void> future = delegate.putAsync(element);
+
+        assertTrue(future.failed());
+        assertEquals("put failure", future.cause().getMessage());
+    }
+
+    @Test
+    public void shouldHandleEvictErrorViaFailedFuture() {
+        doThrow(new RuntimeException("evict failure")).when(mockCache).evict(ELEMENT_KEY);
+
+        Future<Void> future = delegate.evictAsync(ELEMENT_KEY);
+
+        assertTrue(future.failed());
+        assertEquals("evict failure", future.cause().getMessage());
+    }
+}


### PR DESCRIPTION
## Summary
- Validates that the default async methods from `Cache` interface (APIM-13554) work correctly with `NodeCacheDelegate` (in-memory cache)
- Adds 5 tests: async get, async put, async evict, get on missing key returns null, error propagation
- Adds `vertx-core` as test dependency for `Handler`/`AsyncResult`/`Future` types

Relates to APIM-13555

## Test plan
- [x] `mvn test` passes (8 tests: 5 new async + 3 existing)
- [ ] CI green
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.1.0-feat-validate-async-cache-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache/3.1.0-feat-validate-async-cache-SNAPSHOT/gravitee-resource-cache-3.1.0-feat-validate-async-cache-SNAPSHOT.zip)
  <!-- Version placeholder end -->
